### PR TITLE
updated default threshold range to 0.25 - 0.75

### DIFF
--- a/sumo-api/sumo/metrics/evaluator.py
+++ b/sumo-api/sumo/metrics/evaluator.py
@@ -84,7 +84,7 @@ class Evaluator():
         Create and return an dict containing default settings.
         """
 
-        thresholds = np.linspace(0.5, 0.95, 10)
+        thresholds = np.linspace(0.25, 0.75, 11)
         recall_samples = np.linspace(0, 1, 11)
         categories = [
             'air_conditioner',


### PR DESCRIPTION
The previous default range for IoU thresholds was too aggressive, and it was preventing intuitively correct matches from being considered.  Now, at the low end of the range is 40% overlap for equally-sized objects (0.25 IoU).